### PR TITLE
Sigmas math

### DIFF
--- a/stable-diffusion.cpp
+++ b/stable-diffusion.cpp
@@ -1205,7 +1205,7 @@ static std::vector<float> prepare_sigmas(
         if (u < target_len) {
             unsigned char op = custom_sigmas_arr[u];
             float last_parsed_sigma = custom_sigmas_arr[u + 1];
-            LOG_DEBUG("Custom sigmas count (%zu) is less than target steps + 1 (%zu). Propagading last operation (%c%f).", u, target_len, op, last_parsed_sigma);
+            LOG_DEBUG("Custom sigmas count (%zu) is less than target steps + 1 (%zu). Propagating last operation (%c%f).", u, target_len, op, last_parsed_sigma);
             sigmas_for_generation.resize(target_len, 0.0f);
             for (; u < target_len - 1; u++) { // last sigma will be zeroed anyway
                 switch(op) {


### PR DESCRIPTION
@rmatif, hello, maybe add very basic calculations ability?
This would allow to shorten linear sequences.
For example, `--sigmas 15,-0.5` wil make, for 5 steps, sigmas:
`15.0`, `14.5`, `14.0`, `13.5`, `13.0`, `0.0`

Or `--sigmas 16,^0.5,^0.5,^0.5,-1` will make, for 7 steps:
`16.0`, `4.0`, `2.0`, `1.41`, `0.41`, `-0.59`, `-1.59`, `0.0`.

Last math operation is, first, remembered in last 2 positions of `params.custom_sigmas` and then is used to fill missing sigmas for whole steps range.